### PR TITLE
prevent recursive hijack after Reload UI

### DIFF
--- a/lib_inpaint_difference/ui.py
+++ b/lib_inpaint_difference/ui.py
@@ -3,7 +3,7 @@ from modules.shared import opts
 from modules.ui_components import ToolButton
 
 from lib_inpaint_difference.globals import DifferenceGlobals
-from lib_inpaint_background.context_pack import ParentBlock
+from lib_inpaint_difference.context_pack import ParentBlock
 from lib_inpaint_difference.mask_processing import compute_mask
 
 

--- a/lib_inpaint_difference/webui_nasty_hijacks.py
+++ b/lib_inpaint_difference/webui_nasty_hijacks.py
@@ -1,13 +1,25 @@
 import functools
 import gradio as gr
 
-from modules import img2img
+from modules import img2img, shared
 
 from lib_inpaint_difference.stack_ops import find_f_local_in_stack
 from lib_inpaint_difference.globals import DifferenceGlobals
 
+shared.sd_webui_inpaint_difference_hijacks = {}
+
+
+def skip_hijacked(hijacked_name):
+    if shared.sd_webui_inpaint_difference_hijacks.get(hijacked_name):
+        return True
+    shared.sd_webui_inpaint_difference_hijacks[hijacked_name] = True
+    return False
+
 
 def hijack_img2img_processing():
+    if skip_hijacked('hijack_img2img_processing'):
+        return
+
     original_img2img_processing = img2img.img2img
 
     def hijack_func(id_task: str, mode: int, prompt: str, negative_prompt: str, prompt_styles, init_img, sketch,
@@ -41,6 +53,9 @@ def hijack_img2img_processing():
 
 
 def hijack_generation_params_ui():
+    if skip_hijacked('hijack_generation_params_ui'):
+        return
+
     img2img_tabs = find_f_local_in_stack('img2img_tabs')
     for i, tab in enumerate(img2img_tabs):
         def hijack_select(*args, tab_index, original_select, **kwargs):


### PR DESCRIPTION
prevent recursive hijack after `Reload UI`
~~currently the UI breaks `Reload UI`~~
well after your commit [remove gradio tabs hijack](https://github.com/John-WL/sd-webui-inpaint-difference/commit/4b600c1b897e2276f2d21face3a9e1eb83acb54e) it won't break catastrophically after you are reload but it still recursive hijacking which is not good in general
but you also made a typo (I think that that causes the extension to not work entirely) 
so I added another fix [fix wrong reference ](https://github.com/John-WL/sd-webui-inpaint-difference/pull/1/commits/c11a59728bb9e4040553489425973b3b05d1d864)

method by keeping a record of what has already been hijacked in `shared.sd_webui_inpaint_difference_hijacks`